### PR TITLE
feat: allow using : or = as a delimiter

### DIFF
--- a/syntaxes/key-value.tmLanguage.json
+++ b/syntaxes/key-value.tmLanguage.json
@@ -16,7 +16,7 @@
 				"name": "variable.language"
 			},
 			{
-				"match": "^\\s*(\\w+)",
+				"match": "^\\s*([^\\s:=]+)",
 				"name": "keyword"
 			}]
 		}


### PR DESCRIPTION
This might not be what you want to do for this specific module, but I figured I would ask.

I changed the regular expression to look for anything that is not a space or ":" or "=", basically would work the same way but also would take into account keys that have dots or any other type of characters in the key, not only words:

## Screenshots


| BEFORE | AFTER |
| --- | --- |
| ![Screen Shot 2022-11-08 at 1 13 29 PM](https://user-images.githubusercontent.com/8354571/200676710-432277b2-588f-4133-8c68-d859ea9fefc1.png) | ![Screen Shot 2022-11-08 at 1 11 07 PM](https://user-images.githubusercontent.com/8354571/200676484-8d1ad0b8-d454-4f2d-ac03-378a2026e2a3.png) |
| ![Screen Shot 2022-11-08 at 1 13 43 PM](https://user-images.githubusercontent.com/8354571/200677683-f0c1672c-8121-4a84-8c4b-e58dac1c0b3d.png) | ![Screen Shot 2022-11-08 at 1 11 20 PM](https://user-images.githubusercontent.com/8354571/200676486-13bc31a8-a024-4592-92a8-8b4597ee35fe.png) |



## Important

My only question is if regular expressions are applied as FIFO, in other words, if the first pattern matched a comment, will it just skip the rest, or will it also match for keyword.

This is because with my regular expression ^\\s*([^\\s:=]+), this also matches a comment. It basically matches any characters after spaces and then stops if a space or ":" or "=" is found.